### PR TITLE
Resolver problema de minificação do angular

### DIFF
--- a/gulp/tasks/scripts.js
+++ b/gulp/tasks/scripts.js
@@ -38,6 +38,9 @@ module.exports = function (gulp, options, plugins) {
         plugins.jshint.reporter('default')
       )
       .pipe(
+        plugins.if(options.argv.compress, plugins.ngAnnotate())
+      )
+      .pipe(
         plugins.if(options.argv.compress, plugins.uglify())
       )
       .pipe(

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "gulp-jshint": "^2.0.0",
     "gulp-less": "latest",
     "gulp-load-plugins": "^1.2.2",
+    "gulp-ng-annotate": "^2.0.0",
     "gulp-preprocess": "latest",
     "gulp-rename": "latest",
     "gulp-rev": "latest",


### PR DESCRIPTION
## Se mergeado, esse pull request vai...
- Resolver um problema na minificação da aplicação ( [+Infos](http://zpalexander.com/blog/debug-unknown-provider-minified-angularjs/) );
## Por que esta mudança está sendo feita?

Usando as anotações da maneira que usamos hoje, na hora de minificar a aplicação, dispara no browser um erro de unknown provider.

O plugin ngAnnotate resolve isso de maneira automática, dentro do próprio task runner.
